### PR TITLE
Syntax improvements

### DIFF
--- a/languages/elm/brackets.scm
+++ b/languages/elm/brackets.scm
@@ -1,0 +1,3 @@
+("(" @open ")" @close)
+("[" @open "]" @close)
+("{" @open "}" @close)

--- a/languages/elm/config.toml
+++ b/languages/elm/config.toml
@@ -10,4 +10,4 @@ brackets = [
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
     { start = "'", end = "'", close = true, newline = false, not_in = ["string", "comment"] },
 ]
-tab_size = 2
+tab_size = 4

--- a/languages/elm/highlights.scm
+++ b/languages/elm/highlights.scm
@@ -1,72 +1,210 @@
 [
-    "if"
-    "then"
-    "else"
-    "let"
-    "in"
-    (case)
-    (of)
-    (backslash)
-    (as)
-    (port)
-    (exposing)
-    (alias)
-    (import)
-    (module)
-    (type)
-    (arrow)
- ] @keyword
-
-[
-    (eq)
-    (operator_identifier)
-    (colon)
-] @operator
-
-(type_annotation(lower_case_identifier) @function)
-(port_annotation(lower_case_identifier) @function)
-(function_declaration_left(lower_case_identifier) @function.definition)
-
-(function_call_expr
-    target: (value_expr
-        name: (value_qid (lower_case_identifier) @function)))
-
-(exposed_value(lower_case_identifier) @function)
-(exposed_type(upper_case_identifier) @type)
-
-(field_access_expr(value_expr(value_qid)) @identifier)
-(lower_pattern) @variable
-(record_base_identifier) @identifier
-
-[
-    "("
-    ")"
-] @punctuation.bracket
-
-[
-    "|"
-    ","
-] @punctuation.delimiter
-
-(number_constant_expr) @constant
-
-(type_declaration(upper_case_identifier) @type)
-(type_ref) @type
-(type_alias_declaration name: (upper_case_identifier) @type)
-
-(value_expr(upper_case_qid(upper_case_identifier)) @type)
-
-[
-    (line_comment)
-    (block_comment)
+  (line_comment)
+  (block_comment)
 ] @comment
 
-(string_escape) @string.escape
+; Keywords
+;---------
+[
+  (module)
+  (import)
+  (exposing)
+  (port)
+  (type)
+  (alias)
+  (infix)
+  (as)
+  (case)
+  (of)
+  "if"
+  "then"
+  "else"
+  "let"
+  "in"
+] @keyword
+
+; Punctuation
+;------------
+(double_dot) @punctuation.special
 
 [
-    (open_quote)
-    (close_quote)
-    (regular_string_part)
-    (open_char)
-    (close_char)
+  ","
+  "|"
+  (dot)
+] @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+] @punctuation.bracket
+
+; Variables
+;----------
+(value_qid
+  (lower_case_identifier) @variable)
+
+(value_declaration
+  (function_declaration_left
+    (lower_case_identifier) @variable))
+
+(type_annotation
+  (lower_case_identifier) @variable)
+
+(port_annotation
+  (lower_case_identifier) @variable)
+
+(record_base_identifier
+  (lower_case_identifier) @variable)
+
+(lower_pattern
+  (lower_case_identifier) @variable)
+
+(exposed_value
+  (lower_case_identifier) @variable)
+
+(value_qid
+  ((dot)
+    (lower_case_identifier) @variable))
+
+(field_access_expr
+  ((dot)
+    (lower_case_identifier) @variable))
+
+(function_declaration_left
+  (lower_pattern
+    (lower_case_identifier) @variable))
+
+; Functions
+;----------
+(value_declaration
+  functionDeclarationLeft: (function_declaration_left
+    (lower_case_identifier) @function
+    (pattern)))
+
+(value_declaration
+  functionDeclarationLeft: (function_declaration_left
+    (lower_case_identifier) @function
+    pattern: (_)))
+
+(value_declaration
+  functionDeclarationLeft: (function_declaration_left
+    (lower_case_identifier) @function)
+  body: (anonymous_function_expr))
+
+(type_annotation
+  name: (lower_case_identifier) @function
+  typeExpression: (type_expression
+    (arrow)))
+
+(port_annotation
+  name: (lower_case_identifier) @function
+  typeExpression: (type_expression
+    (arrow)))
+
+(function_call_expr
+  target: (value_expr
+    (value_qid
+      (lower_case_identifier) @function)))
+
+; Operators
+;----------
+[
+  (operator_identifier)
+  (eq)
+  (colon)
+  (arrow)
+  (backslash)
+  "::"
+] @operator
+
+; Modules
+;--------
+(module_declaration
+  (upper_case_qid
+    (upper_case_identifier) @title))
+
+(import_clause
+  (upper_case_qid
+    (upper_case_identifier) @title))
+
+(as_clause
+  (upper_case_identifier) @title)
+
+(value_expr
+  (value_qid
+    (upper_case_identifier) @title))
+
+; Types
+;------
+(type_declaration
+  (upper_case_identifier) @type)
+
+(type_ref
+  (upper_case_qid
+    (upper_case_identifier) @type))
+
+(type_variable
+  (lower_case_identifier) @type)
+
+(lower_type_name
+  (lower_case_identifier) @type)
+
+(exposed_type
+  (upper_case_identifier) @type)
+
+(type_alias_declaration
+  (upper_case_identifier) @type)
+
+(field_type
+  name: (lower_case_identifier) @property)
+
+(field
+  name: (lower_case_identifier) @property)
+
+(type_declaration
+  (union_variant
+    (upper_case_identifier) @constructor))
+
+(nullary_constructor_argument_pattern
+  (upper_case_qid
+    (upper_case_identifier) @constructor))
+
+(union_pattern
+  (upper_case_qid
+    (upper_case_identifier) @constructor))
+
+(value_expr
+  (upper_case_qid
+    (upper_case_identifier)) @constructor)
+
+; Literals
+;---------
+(number_constant_expr
+  (number_literal) @number)
+
+(upper_case_qid
+  ((upper_case_identifier) @boolean
+    (#any-of? @boolean "True" "False")))
+
+[
+  (open_quote)
+  (close_quote)
+  (open_char)
+  (close_char)
 ] @string
+
+(string_constant_expr
+  (string_escape) @string)
+
+(string_constant_expr
+  (regular_string_part) @string)
+
+(char_constant_expr
+  (string_escape) @string)
+
+(char_constant_expr
+  (regular_string_part) @string)


### PR DESCRIPTION
Moved from https://github.com/zed-industries/zed/pull/22293.

- Fixes various issues with current syntax highlighting: modules and patterns are not highlighted, number literals are treated as constants etc. New highlights are mostly copied from [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/queries/elm/highlights.scm) with some modifications and removals of things that are not supported by Zed. In particular, `@modules` are highlighted as `@title`, similarly to how it's done in Zed's Haskell extension.
- Added `brackets.scm`.
- Changed the default tab_size to 4 as that's how most of Elm projects are formatted and what elm-format uses.