### PR TITLE
Prefer `elm-language-server` from `PATH` if available

### DIFF
--- a/src/elm.rs
+++ b/src/elm.rs
@@ -5,6 +5,7 @@ use zed::{
 };
 use zed_extension_api::{self as zed, Result};
 
+const BINARY_NAME: &str = "elm-language-server";
 const SERVER_PATH: &str = "node_modules/@elm-tooling/elm-language-server/out/node/index.js";
 const PACKAGE_NAME: &str = "@elm-tooling/elm-language-server";
 
@@ -68,8 +69,16 @@ impl zed::Extension for ElmExtension {
     fn language_server_command(
         &mut self,
         server_id: &zed::LanguageServerId,
-        _worktree: &zed::Worktree,
+        worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
+        if let Some(binary_path) = worktree.which(BINARY_NAME) {
+            return Ok(zed::Command {
+                command: binary_path,
+                args: vec!["--stdio".to_string()],
+                env: Default::default(),
+            });
+        }
+
         let server_path = self.server_script_path(server_id)?;
         Ok(zed::Command {
             command: zed::node_binary_path()?,


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/21123

Tested with

```sh
nix shell nixpkgs#elmPackages.elm-language-server
which elm-language-server /nix/store/3511jcgypk187lrydnbg7j6bgyab35q4-elm-language-server-2.8.0/bin/elm-language-server
zed --foreground
...
2026-01-11T16:45:07+01:00 INFO  [lsp] starting language server process. binary path: "/nix/store/3511jcgypk187lrydnbg7j6bgyab35q4-elm-language-server-2.8.0/bin/elm-language-server", working directory: "/Users/unsoundscapes/Src/Github/elm-pool", args: ["--stdio"]
...
```
